### PR TITLE
Missing openshift client plugin

### DIFF
--- a/jenkins/plugins.txt
+++ b/jenkins/plugins.txt
@@ -75,3 +75,4 @@ job-dsl:1.59
 pipeline-milestone-step
 lockable-resources
 embeddable-build-status
+openshift-client


### PR DESCRIPTION
After removing plugin binary forgot to add openshift client
back into the plugin list.